### PR TITLE
Run ts-npm-lint when finished building

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "merge2": "1.0.1",
     "object-assign": "4.0.1",
     "touch": "1.0.0",
+    "ts-npm-lint": "^0.1.0",
     "tslint": "3.6.0",
     "typescript": "1.8.9"
   }

--- a/src/TypeScriptTask.ts
+++ b/src/TypeScriptTask.ts
@@ -1,3 +1,5 @@
+const tsdLinter = require('ts-npm-lint');
+
 import {
 GulpTask
 } from 'gulp-core-build';
@@ -97,6 +99,14 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
         if (this.taskConfig.failBuildOnErrors && errorCount) {
           completeCallback('TypeScript error(s) occured.');
         } else {
+          // Without this, the built .d.ts files will contain /// references
+          // to "../typings/tsd.d.ts" which won't resolve properly for projects
+          // that consume our NPM package.  ts-npm-lint is a workaround that strips
+          // those lines.  IntelliSense will still find the typings as long as
+          // they're present in the consumer's tsd.d.ts file.
+          // NOTE: The TypeScript team expects to have an official solution for us soon.
+          tsdLinter.fixTypings();
+
           completeCallback();
         }
       })


### PR DESCRIPTION
Ensure that ts-npm-lint gets run once a build is completed.

Make sure to publish a new version of gulp-core-build-typescript