### PR TITLE
Adds a cache for TsLint task

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp-typescript": "2.12.1",
     "gulp-util": "3.0.7",
     "lodash": "4.11.2",
+    "md5": "^2.1.0",
     "merge2": "1.0.1",
     "object-assign": "4.0.1",
     "through2": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "gulp": "~3.9.1",
-    "gulp-cache": "^0.4.5",
+    "gulp-cache": "0.4.5",
     "gulp-changed": "1.3.0",
     "gulp-core-build": "~0.7.0",
     "gulp-plumber": "1.1.0",
@@ -16,7 +16,7 @@
     "gulp-typescript": "2.12.1",
     "gulp-util": "3.0.7",
     "lodash": "4.11.2",
-    "md5": "^2.1.0",
+    "md5": "2.1.0",
     "merge2": "1.0.1",
     "object-assign": "4.0.1",
     "through2": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "gulp": "~3.9.1",
+    "gulp-cache": "^0.4.5",
     "gulp-changed": "1.3.0",
     "gulp-core-build": "~0.7.0",
     "gulp-plumber": "1.1.0",

--- a/src/TSLintTask.ts
+++ b/src/TSLintTask.ts
@@ -7,6 +7,7 @@ import through2 = require('through2');
 import gutil = require('gulp-util');
 import tslint = require('tslint');
 import { merge } from 'lodash';
+import md5 = require('md5');
 import * as path from 'path';
 import * as lintTypes from 'tslint/lib/lint';
 import * as ts from 'typescript';
@@ -96,6 +97,10 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
           this.push(file);
           callback();
         }), {
+          // Scope the cache to a combination of the lint rules and the build path
+          name: md5(
+            tslint.VERSION + JSON.stringify(taskScope._loadLintRules()) +
+            taskScope.name + taskScope.buildConfig.rootPath),
           // What on the result indicates it was successful
           success: (jshintedFile: gutil.File): boolean => {
             /* tslint:disable:no-string-literal */

--- a/src/TSLintTask.ts
+++ b/src/TSLintTask.ts
@@ -1,5 +1,8 @@
 import { GulpTask } from 'gulp-core-build';
 import gulpType = require('gulp');
+/* tslint:disable:typedef */
+const cached = require('gulp-cache');
+/* tslint:enable:typedef */
 import through2 = require('through2');
 import gutil = require('gulp-util');
 import tslint = require('tslint');
@@ -48,22 +51,21 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
     useOldConfig: false
   };
 
+  /* tslint:disable:no-any */
+  private _lintRules: any = undefined;
+  /* tslint:enable:no-any */
+
   public executeTask(gulp: gulpType.Gulp): NodeJS.ReadWriteStream {
     const taskScope: TSLintTask = this;
 
-    if (this.taskConfig.lintConfig) {
-      /* tslint:disable:no-any */
-      const defaultConfig: any = this.taskConfig.useOldConfig
-      /* tslint:enable:no-any */
-        ? require('./defaultTslint_oldRules.json')
-        : require('./defaultTslint.json');
-      this.taskConfig.lintConfig = merge(defaultConfig, this.taskConfig.lintConfig);
-
-      return gulp.src(this.taskConfig.sourceMatch)
-        .pipe(through2.obj(function(
+    return gulp.src(this.taskConfig.sourceMatch)
+      .pipe(cached(
+        through2.obj(function(
           file: gutil.File,
           encoding: string,
           callback: (encoding?: string, file?: gutil.File) => void): void {
+          taskScope.logVerbose(file.path);
+
           // Lint the file
           if (file.isNull()) {
             return callback(undefined, file);
@@ -76,7 +78,7 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
           }
 
           const options: lintTypes.ILinterOptions = {
-            configuration: taskScope.taskConfig.lintConfig,
+            configuration: taskScope._loadLintRules(),
             formatter: 'json',
             formattersDirectory: undefined, // not used, use reporters instead
             rulesDirectory: taskScope.taskConfig.rulesDirectory || []
@@ -93,7 +95,25 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
 
           this.push(file);
           callback();
-        }));
+        }), {
+          // What on the result indicates it was successful
+          success: (jshintedFile: gutil.File): boolean => {
+            /* tslint:disable:no-string-literal */
+            return jshintedFile['tslint'].failureCount === 0;
+            /* tslint:enable:no-string-literal */
+          }
+        }
+      ));
+  }
+  /* tslint:disable:no-any */
+  private _loadLintRules(): any {
+    if (!this._lintRules) {
+      const defaultConfig: any = this.taskConfig.useOldConfig
+  /* tslint:enable:no-any */
+        ? require('./defaultTslint_oldRules.json')
+        : require('./defaultTslint.json');
+      this._lintRules = merge(defaultConfig, this.taskConfig.lintConfig || {});
     }
+    return this._lintRules;
   }
 }

--- a/tsd.json
+++ b/tsd.json
@@ -7,6 +7,9 @@
   "installed": {
     "lodash/lodash.d.ts": {
       "commit": "73f7bb99692823f1811817f9753a02b57af5305e"
+    },
+    "md5/md5.d.ts": {
+      "commit": "473232e5dbd179e9ee682fab12f796720f37b118"
     }
   }
 }

--- a/typings/md5/md5.d.ts
+++ b/typings/md5/md5.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for md5 v2.1.0
+// Project: https://github.com/pvorb/node-md5
+// Definitions by: Bill Sourour <https://github.com/arcdev1>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="../main/ambient/node/index.d.ts" />
+declare module 'md5' {
+/**
+ * js function for hashing messages with MD5
+ *
+ * @param {(string | Buffer)} message - a string or buffer to hash
+ * @returns {string} the resultant MD5 hash of the given message
+ */
+    function main(message: string | Buffer): string;
+    export = main;
+}

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,1 +1,2 @@
 /// <reference path="lodash/lodash.d.ts" />
+/// <reference path="md5/md5.d.ts" />


### PR DESCRIPTION
Adds a file based cache for TsLint.
* Cuts linting of sp-client-platform from 7.16s -> 1s
* Initial caching takes some time, works even after a gulp nuke

To-do's:
* Add typings for gulp-cache
* We should have a command which clears the caches
* Add a flag for using caching or not (until caching is fully rolled out)