### PR TITLE
Reduce cache size

### DIFF
--- a/src/TSLintTask.ts
+++ b/src/TSLintTask.ts
@@ -106,6 +106,12 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
             /* tslint:disable:no-string-literal */
             return jshintedFile['tslint'].failureCount === 0;
             /* tslint:enable:no-string-literal */
+          },
+          value: (file: gutil.File): Object => {
+            return {
+              contents: file.contents.toString('base64'),
+              path: file.path
+            };
           }
         }
       ));

--- a/src/TSLintTask.ts
+++ b/src/TSLintTask.ts
@@ -110,7 +110,9 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
           // By default, the cache attempts to store the value of the objects in the stream
           // For this task, this is over-engineering since we never need to store anything extra.
           value: (file: gutil.File): Object => {
-            return { };
+            return {
+              path: file.path
+            };
           }
         }
       ));

--- a/src/TSLintTask.ts
+++ b/src/TSLintTask.ts
@@ -107,11 +107,10 @@ export class TSLintTask extends GulpTask<ITSLintTaskConfig> {
             return jshintedFile['tslint'].failureCount === 0;
             /* tslint:enable:no-string-literal */
           },
+          // By default, the cache attempts to store the value of the objects in the stream
+          // For this task, this is over-engineering since we never need to store anything extra.
           value: (file: gutil.File): Object => {
-            return {
-              contents: file.contents.toString('base64'),
-              path: file.path
-            };
+            return { };
           }
         }
       ));


### PR DESCRIPTION
The gulp-cache stores the objects from the stream into the cache, however, this is not necessary. This is because we only care about linting files that are NOT in the cache, and we never look at the values in the cache.