### PR TITLE
Configure the source root to SRC folder.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-core-build-typescript",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/TypeScriptTask.ts
+++ b/src/TypeScriptTask.ts
@@ -91,7 +91,7 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
       .pipe(ts(tsProject, undefined, this.taskConfig.reporter));
 
     allStreams.push(tsResult.js
-      .pipe(sourcemaps.write('.'))
+      .pipe(sourcemaps.write('.', { sourceRoot: '/src' }))
       .pipe(gulp.dest(libFolder)));
 
     allStreams.push(tsResult.dts.pipe(gulp.dest(libFolder)));
@@ -115,12 +115,12 @@ export class TypeScriptTask extends GulpTask<ITypeScriptTaskConfig> {
             errorCount++;
           }
         }))
-        .pipe(sourcemaps.write())
+        .pipe(sourcemaps.write({ sourceRoot: '/src' }))
         .pipe(ts(tsAMDProject, undefined, this.taskConfig.reporter));
 
       allStreams.push(
         tsResult.js
-          .pipe(sourcemaps.write('.'))
+          .pipe(sourcemaps.write('.', { sourceRoot: '/src' }))
           .pipe(gulp.dest(libAMDFolder)));
 
       allStreams.push(tsResult.dts.pipe(gulp.dest(libAMDFolder)));


### PR DESCRIPTION
Doc: https://github.com/floridoo/gulp-sourcemaps#write-options

Configure the source root to `/src` folder. VS Code is using the source root to map the compiled file back to the original file.